### PR TITLE
clone value if it's null

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function decorator (Component) {
 }
 
 function clone (val) {
-  if (typeof val !== 'object') {
+  if (val === null || typeof val !== 'object') {
     return val
   } else if (Array.isArray(val)) {
     return val.map(clone)


### PR DESCRIPTION
clone value if it's `null`
otherwise throws an exception `Uncaught TypeError: Can not convert undefined or null to object`