### PR TITLE
Added the ability to decorate without options

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,38 +15,48 @@ var internalHooks = [
   'activate'
 ]
 
-function decorator (options) {
-  return function (Component) {
-    options.name = options.name || Component.name
-    // prototype props.
-    var proto = Component.prototype
-    Object.getOwnPropertyNames(proto).forEach(function (key) {
-      if (key === 'constructor') {
-        return
-      }
-      // hooks
-      if (internalHooks.indexOf(key) > -1) {
-        options[key] = proto[key]
-        return
-      }
-      var descriptor = Object.getOwnPropertyDescriptor(proto, key)
-      if (typeof descriptor.value === 'function') {
-        // methods
-        (options.methods || (options.methods = {}))[key] = descriptor.value
-      } else if (descriptor.get || descriptor.set) {
-        // computed properties
-        (options.computed || (options.computed = {}))[key] = {
-          get: descriptor.get,
-          set: descriptor.set
-        }
-      }
-    })
-    // find super
-    var Super = proto.__proto__.constructor
-    if (!(Super instanceof Vue)) {
-      Super = Vue
+function componentFactory (Component, options) {
+  if (!options) {
+    options = {}
+  }
+  options.name = options.name || Component.name
+  // prototype props.
+  var proto = Component.prototype
+  Object.getOwnPropertyNames(proto).forEach(function (key) {
+    if (key === 'constructor') {
+      return
     }
-    return Super.extend(options)
+    // hooks
+    if (internalHooks.indexOf(key) > -1) {
+      options[key] = proto[key]
+      return
+    }
+    var descriptor = Object.getOwnPropertyDescriptor(proto, key)
+    if (typeof descriptor.value === 'function') {
+      // methods
+      (options.methods || (options.methods = {}))[key] = descriptor.value
+    } else if (descriptor.get || descriptor.set) {
+      // computed properties
+      (options.computed || (options.computed = {}))[key] = {
+        get: descriptor.get,
+        set: descriptor.set
+      }
+    }
+  })
+  // find super
+  var Super = proto.__proto__.constructor
+  if (!(Super instanceof Vue)) {
+    Super = Vue
+  }
+  return Super.extend(options)
+}
+
+function decorator (options) {
+  if (typeof options === 'function') {
+    return componentFactory(options)
+  }
+  return function (Component) {
+    return componentFactory(Component, options)
   }
 }
 


### PR DESCRIPTION
to create the components that do not need such options as a template, props, replace, etc
This is useful when mounting component to the existing DOM-element and it already contains a template with the expressions and need only data, methods, computer and hooks
eg
```js
import Component from 'vue-class-component'

@Component
class Some {
  data () {
    ...
  }
  someHandler() {
    ...
  }
  get someComputed() {
    ...
  }
}
```