### PR TITLE
Update prop option type for Vue 1.0.21+

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 export interface PropOption {
-    type?: { new (...args: any[]): any; };
+    type?: { new (...args: any[]): any; } | { new (...args: any[]): any; }[];
     required?: boolean;
     default?: any;
     twoWay?: boolean;


### PR DESCRIPTION
To accept multiple constructors for `type` in prop option.