### PR TITLE
Compatibility with native class

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -65,12 +65,8 @@ export function componentFactory (
 
   // find super
   const superProto = Object.getPrototypeOf(Component.prototype)
-  if (!(superProto instanceof Vue)) {
-    Component.prototype = Object.create(Vue.prototype)
-    Component.prototype.constructor = Component
-    Object.keys(Vue).forEach(key => {
-      Component[key] = Vue[key]
-    })
-  }
-  return Component.extend(options)
+  const Super = superProto instanceof Vue
+    ? superProto.constructor as VueClass
+    : Vue
+  return Super.extend(options)
 }

--- a/src/data.ts
+++ b/src/data.ts
@@ -3,19 +3,19 @@ import { VueClass } from './declarations'
 import { noop } from './util'
 
 export function collectDataFromConstructor (vm: Vue, Component: VueClass) {
-  // Create dummy Vue instance to collect
-  // initial class properties from the component constructor.
-  // To prevent to print warning,
-  // the data object should inherit Vue.prototype.
-  const data = Object.create(vm, {
-    _init: {
-      get: () => noop
-    }
-  })
+  // override _init to prevent to init as Vue instance
+  Component.prototype._init = function (this: Vue) {
+    // proxy to actual vm
+    Object.getOwnPropertyNames(vm).forEach(key => {
+      Object.defineProperty(this, key, {
+        get: () => vm[key],
+        set: value => vm[key] = value
+      })
+    })
+  }
 
-  // call constructor with passing dummy instance
-  // `data` object will have initial data
-  Component.call(data)
+  // should be acquired class property values
+  const data = new Component()
 
   // create plain data object
   const plainData = {}


### PR DESCRIPTION
This PR fixes #33.

Some errors will be occurred if we use JavaScript native class since it does not allow updating `prototype` and must be called with `new` keyword.

I've revert the code of extending component constructor and change the approach to collect class properties...