### PR TITLE
should not collect uninitialized class properties

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -20,7 +20,9 @@ export function collectDataFromConstructor (vm: Vue, Component: VueClass) {
   // create plain data object
   const plainData = {}
   Object.keys(data).forEach(key => {
-    plainData[key] = data[key]
+    if (data[key] !== undefined) {
+      plainData[key] = data[key]
+    }
   })
 
   return plainData

--- a/test/test-babel.js
+++ b/test/test-babel.js
@@ -1,4 +1,4 @@
-import Component from '../lib/index'
+import Component, { createDecorator } from '../lib/index'
 import { expect } from 'chai'
 import Vue from 'vue'
 
@@ -16,5 +16,23 @@ describe('vue-class-component with Babel', () => {
     }
     const c = new MyComp()
     expect(c.foo).to.equal('hello')
+  })
+
+  it('should not collect uninitialized class properties', () => {
+    const Prop = createDecorator((options, key) => {
+      if (!options.props) {
+        options.props = {}
+      }
+      options.props[key] = true
+    })
+
+    @Component
+    class MyComp {
+      foo
+      @Prop bar
+    }
+    const c = new MyComp()
+    expect('foo' in c.$data).to.be.false
+    expect('bar' in c.$data).to.be.false
   })
 })


### PR DESCRIPTION
In the environment of Babel + Decorator, decorated class properties are treated as enumerable even if we does not set initial value. That causes unexpected initialization of data, reported on #31 

I've just added `undefined` check in the data collection process.