### PR TITLE
webpack to beta.27; rimraf for cross platform support

### DIFF
--- a/example/example.ts
+++ b/example/example.ts
@@ -48,7 +48,7 @@ class App extends Vue {
 }
 
 // mount
-new App({
+new Vue({
   el: '#el',
   render: h => h(App, { props: { propMessage: 'World!' }})
 })

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
       {
         test: /\.ts$/,
         exclude: /node_modules|vue\/src/,
-        loader: 'ts'
+        loader: 'ts-loader'
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "tsc -p .",
-    "clean": "rm -rf lib",
+    "clean": "rimraf ./lib",
     "example": "npm run build && webpack --config example/webpack.config.js",
     "dev": "webpack --config example/webpack.config.js --watch",
     "test": "npm run build && webpack --config test/webpack.config.js && mocha test/test.build.js",
@@ -43,9 +43,10 @@
     "chai": "^3.5.0",
     "mocha": "^3.1.2",
     "node-libs-browser": "^1.0.0",
+    "rimraf": "^2.5.4",
     "ts-loader": "^0.9.5",
     "typescript": "^2.0.6",
     "vue": "^2.0.3",
-    "webpack": "^2.1.0-beta.25"
+    "webpack": "^2.1.0-beta.27"
   }
 }

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -12,12 +12,12 @@ module.exports = {
       {
         test: /\.ts$/,
         exclude: /node_modules|vue\/src/,
-        loader: 'ts'
+        loader: 'ts-loader'
       },
       {
         test: /\.js$/,
         exclude: /node_modules|vue\/src/,
-        loader: 'babel'
+        loader: 'babel-loader'
       }
     ]
   }


### PR DESCRIPTION
- Fix breaking change for [webpack@2.1.0-beta.26](https://github.com/webpack/webpack/releases/tag/v2.1.0-beta.26)
- Add rimraf for windows support