### PR TITLE
Allow to get initial property in user defined decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ class MyComp extends Vue {
 }
 ```
 
+#### Process Initial Property on Custom Decorators
+
+If you pass the object that has `hookInitialProperty: true` option, `createDecorator`'s callback will receive initial value of each property as the 3rd argument. Note that the properties will no longer be collected as component data in that case.
+
 ### Adding Custom Hooks
 
 If you use some Vue plugins like Vue Router, you may want class components to resolve hooks that they provides. For that case, `Component.registerHooks` allows you to register such hooks:

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ class MyComp extends Vue {
 
 #### Process Initial Property on Custom Decorators
 
-If you pass the object that has `hookInitialProperty: true` option, `createDecorator`'s callback will receive initial value of each property as the 3rd argument. Note that the properties will no longer be collected as component data in that case.
+If you pass the object that has `getInitialProperty: true` option, `createDecorator`'s callback will receive initial value of each property as the 3rd argument. Note that the properties will no longer be collected as component data in that case.
 
 ### Adding Custom Hooks
 

--- a/src/component.ts
+++ b/src/component.ts
@@ -77,6 +77,6 @@ function applyDecorators (
   const data = new Component()
 
   forEachValues(meta.decoratorMap, (fn, key) => {
-    fn(options, meta.propertyNameMap[key] && data[key])
+    fn(options, meta.decoratorAwaredKeys[key] && data[key])
   })
 }

--- a/src/data.ts
+++ b/src/data.ts
@@ -15,6 +15,7 @@ export function collectDataFromConstructor (
       Object.defineProperty(this, key, {
         get: () => vm[key],
         set: noop,
+        configurable: true
       })
     })
   }

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,15 +1,20 @@
 import * as Vue from 'vue'
 import { VueClass } from './declarations'
 import { noop, warn } from './util'
+import { Meta } from './meta'
 
-export function collectDataFromConstructor (vm: Vue, Component: VueClass) {
+export function collectDataFromConstructor (
+  vm: Vue,
+  Component: VueClass,
+  meta: Meta | undefined
+) {
   // override _init to prevent to init as Vue instance
   Component.prototype._init = function (this: Vue) {
     // proxy to actual vm
     Object.getOwnPropertyNames(vm).forEach(key => {
       Object.defineProperty(this, key, {
         get: () => vm[key],
-        set: value => vm[key] = value
+        set: noop,
       })
     })
   }
@@ -20,7 +25,10 @@ export function collectDataFromConstructor (vm: Vue, Component: VueClass) {
   // create plain data object
   const plainData = {}
   Object.keys(data).forEach(key => {
-    if (data[key] !== undefined) {
+    if (
+      data[key] !== undefined
+      && (!meta || !meta.propertyNameMap[key])
+    ) {
       plainData[key] = data[key]
     }
   })

--- a/src/data.ts
+++ b/src/data.ts
@@ -28,7 +28,7 @@ export function collectDataFromConstructor (
   Object.keys(data).forEach(key => {
     if (
       data[key] !== undefined
-      && (!meta || !meta.propertyNameMap[key])
+      && (!meta || !meta.decoratorAwaredKeys[key])
     ) {
       plainData[key] = data[key]
     }

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -1,3 +1,6 @@
 import * as Vue from 'vue'
+import { Meta } from './meta'
 
 export type VueClass = { new (): Vue } & typeof Vue
+
+export type VueInternal = Vue & { __vue_component_meta__?: Meta }

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -1,6 +1,8 @@
 import * as Vue from 'vue'
 import { Meta } from './meta'
 
+export type Dictionary<T> = { [key: string]: T }
+
 export type VueClass = { new (): Vue } & typeof Vue
 
 export type VueInternal = Vue & { __vue_component_meta__?: Meta }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,14 @@
 import * as Vue from 'vue'
 import { VueClass } from './declarations'
-import { componentFactory, $internalHooks } from './component'
+import { componentFactory } from './component'
+import { Meta } from './meta'
 
-export { createDecorator } from './util'
+export { createDecorator } from './meta'
 
 function Component <U extends Vue>(options: Vue.ComponentOptions<U>): <V extends VueClass>(target: V) => V
 function Component <V extends VueClass>(target: V): V
 function Component <V extends VueClass, U extends Vue>(
- options: Vue.ComponentOptions<U> | V
+  options: Vue.ComponentOptions<U> | V
 ): any {
   if (typeof options === 'function') {
     return componentFactory(options)
@@ -19,7 +20,7 @@ function Component <V extends VueClass, U extends Vue>(
 
 namespace Component {
   export function registerHooks (keys: string[]): void {
-    $internalHooks.push(...keys)
+    Meta.internalHooks.push(...keys)
   }
 }
 

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -42,7 +42,7 @@ export class Meta {
 }
 
 export interface CreateDecoratorOptions {
-  hookInitialProperty?: boolean
+  getInitialProperty?: boolean
 }
 
 // Property or method decorators
@@ -70,7 +70,7 @@ export function createDecorator (
     }
 
     // Allow to process an initial property on userland
-    if (options.hookInitialProperty) {
+    if (options.getInitialProperty) {
       meta.propertyNameMap[key] = true
     }
 

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -34,10 +34,10 @@ export class Meta {
    * Property names that indicates the initial property will be
    * processed on user-defined decorators. Also they will not collected in `data` hook.
    */
-  propertyNameMap: Dictionary<boolean> = {}
+  decoratorAwaredKeys: Dictionary<boolean> = {}
 
   get shouldGetInitalProperty () {
-    return Object.keys(this.propertyNameMap).length > 0
+    return Object.keys(this.decoratorAwaredKeys).length > 0
   }
 }
 
@@ -71,7 +71,7 @@ export function createDecorator (
 
     // Allow to process an initial property on userland
     if (options.getInitialProperty) {
-      meta.propertyNameMap[key] = true
+      meta.decoratorAwaredKeys[key] = true
     }
 
     meta.decoratorMap[key] = (options, value) => {

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -1,0 +1,59 @@
+/**
+ * Managing `meta data` of each component that includes
+ * internalHooks and decoratorQueue. Since the property
+ * decorators are called before creating component constructor,
+ * we need to store decorator hooks globaly and call it
+ * in component's class decorator later.
+ */
+
+import * as Vue from 'vue'
+import { VueInternal } from './declarations'
+
+export class Meta {
+  /**
+   * The method names that the component decorator will
+   * just register on component options object.
+   * We can extend this list by using `Component.registerHooks`.
+   */
+  static internalHooks = [
+    'data', 'beforeCreate', 'created', 'beforeMount', 'mounted',
+    'beforeDestroy', 'destroyed', 'beforeUpdate', 'updated',
+    'activated', 'deactivated', 'render'
+  ]
+
+  /**
+   * Property, method and parameter decorators created by `createDecorator` helper
+   * will enqueue functions that update component options for lazy processing.
+   * They will be executed just before creating component constructor.
+   */
+  decoratorQueue: ((options: Vue.ComponentOptions<Vue>) => void)[] = []
+}
+
+
+export interface CreateDecoratorOptions {
+  hookPropertyInitializer?: (options: Vue.ComponentOptions<Vue>, value: any) => void
+}
+
+export function createDecorator (
+  factory: (options: Vue.ComponentOptions<Vue>, key: string) => void
+): (target: Vue, key: string) => void
+export function createDecorator (
+  factory: (options: Vue.ComponentOptions<Vue>, key: string, index: number) => void
+): (target: Vue, key: string, index: number) => void
+export function createDecorator (
+  factory: (options: Vue.ComponentOptions<Vue>, key: string, index: number) => void
+): (target: VueInternal, key: string, index: any) => void {
+  return (proto, key, index) => {
+    let meta = proto.__vue_component_meta__
+    if (!meta) {
+      proto.__vue_component_meta__ = meta = new Meta()
+    }
+
+    // Do not expose property descriptor
+    if (typeof index !== 'number') {
+      index = undefined
+    }
+
+    meta.decoratorQueue.push(options => factory(options, key, index))
+  }
+}

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -1,8 +1,8 @@
 /**
  * Managing `meta data` of each component that includes
- * internalHooks and decoratorQueue. Since the property
+ * special method names and user defined decorator hooks. Since the property
  * decorators are called before creating component constructor,
- * we need to store decorator hooks globaly and call it
+ * we need to store decorator hooks in each prototype object and call it
  * in component's class decorator later.
  */
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,24 +1,4 @@
-import * as Vue from 'vue'
-import { $decoratorQueue } from './component'
-
 export const noop = () => {}
-
-export function createDecorator (
-  factory: (options: Vue.ComponentOptions<Vue>, key: string) => void
-): (target: Vue, key: string) => void
-export function createDecorator (
-  factory: (options: Vue.ComponentOptions<Vue>, key: string, index: number) => void
-): (target: Vue, key: string, index: number) => void
-export function createDecorator (
-  factory: (options: Vue.ComponentOptions<Vue>, key: string, index: number) => void
-): (target: Vue, key: string, index: any) => void {
-  return (_, key, index) => {
-    if (typeof index !== 'number') {
-      index = undefined
-    }
-    $decoratorQueue.push(options => factory(options, key, index))
-  }
-}
 
 export function warn (message: string): void {
   if (typeof console !== 'undefined') {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,16 @@
+import { Dictionary } from './declarations'
+
 export const noop = () => {}
 
 export function warn (message: string): void {
   if (typeof console !== 'undefined') {
     console.warn('[vue-class-component] ' + message)
   }
+}
+
+export function forEachValues <T> (
+  obj: Dictionary<T>,
+  fn: (value: T, key: string) => void
+): void {
+  Object.keys(obj).forEach(key => fn(obj[key], key))
 }

--- a/test/test-babel.js
+++ b/test/test-babel.js
@@ -69,4 +69,28 @@ describe('vue-class-component with Babel', () => {
 
     expect(spy).to.have.been.called.with(message)
   })
+
+  it('should hook initial property by a custom decorator', () => {
+    const Prop = createDecorator((options, key, value) => {
+      (options.props || (options.props = {}))[key] = {
+        default: value + ' test'
+      }
+    }, {
+      hookInitialProperty: true
+    })
+
+    @Component
+    class MyComp extends Vue {
+      @Prop foo = 'default value'
+    }
+
+    const c1 = new MyComp()
+    const c2 = new MyComp({
+      propsData: {
+        foo: 'prop value'
+      }
+    })
+    expect(c1.foo).to.equal('default value test')
+    expect(c2.foo).to.equal('prop value')
+  })
 })

--- a/test/test-babel.js
+++ b/test/test-babel.js
@@ -76,7 +76,7 @@ describe('vue-class-component with Babel', () => {
         default: value + ' test'
       }
     }, {
-      hookInitialProperty: true
+      getInitialProperty: true
     })
 
     @Component

--- a/test/test.ts
+++ b/test/test.ts
@@ -190,4 +190,28 @@ describe('vue-class-component', () => {
     expect(c.bar).to.equal('world')
     expect((MyComp as any).options.computed.bar.cache).to.be.false
   })
+
+  it('createDecorator: hook initial property', function () {
+    const Prop = createDecorator((options, key, value) => {
+      (options.props || (options.props = {}))[key] = {
+        default: value + ' test'
+      }
+    }, {
+      hookInitialProperty: true
+    })
+
+    @Component
+    class MyComp extends Vue {
+      @Prop foo = 'default value'
+    }
+
+    const c1 = new MyComp()
+    const c2 = new MyComp({
+      propsData: {
+        foo: 'prop value'
+      }
+    })
+    expect(c1.foo).to.equal('default value test')
+    expect(c2.foo).to.equal('prop value')
+  })
 })

--- a/test/test.ts
+++ b/test/test.ts
@@ -197,7 +197,7 @@ describe('vue-class-component', () => {
         default: value + ' test'
       }
     }, {
-      hookInitialProperty: true
+      getInitialProperty: true
     })
 
     @Component


### PR DESCRIPTION
This patch allows us to acquire an initial property in user defined decorators. If we set `getInitialProperty: true` option of `createDecorator`, we will receive an initial property as the 3rd argument of the callback function.

``` js
createDecorator((options, key, initialValue) => {
  console.log(initialValue)
}, {
  getInitialProperty: true
})
```

In addition, the properties will be no longer collected as component data if it is decorated by the decorator that is enabled `getInitialProperty` option.

I've also separated decorator related logics in `meta.ts` since it seems a bit complicated thing.

Fix #60 