### PR TITLE
Allow to set tagName with decorator

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -68,5 +68,12 @@ export function componentFactory (
   const Super = superProto instanceof Vue
     ? superProto.constructor as VueClass
     : Vue
-  return Super.extend(options)
+
+  const Sub = Super.extend(options)
+  if (options.name) {
+      Object.defineProperty(Sub, 'name', {
+        value: options.name
+      })
+  }
+  return Sub
 }


### PR DESCRIPTION
``` javascript
import Vue from 'vue'
import Component from 'vue-class-component'

@Component({
  name: 'app'
})
export default class App extends Vue {
  public name: string;
}
```