### PR TITLE
chore(example): update sfc declaration

### DIFF
--- a/example/sfc.d.ts
+++ b/example/sfc.d.ts
@@ -1,4 +1,4 @@
 declare module "*.vue" {
   import Vue from 'vue'
-  export default typeof Vue
+  export default Vue
 }


### PR DESCRIPTION
I'm not sure why/when this declaration does not work. It seems to should be `export default Vue` rather than `export default typeof Vue` now.

/ping @HerringtonDarkholme @kaorun343 

Fix #123 