### PR TITLE
Update README.md to support beforeRouteUpdate hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ import Component from 'vue-class-component'
 // Register the router hooks with their names
 Component.registerHooks([
   'beforeRouteEnter',
-  'beforeRouteLeave'
+  'beforeRouteLeave',
+  'beforeRouteUpdate' // for vue-router 2.2+
 ])
 ```
 


### PR DESCRIPTION
**vue-router** v2.2+ has new lifecycle event called `beforeRouteUpdate` ([documentation](https://router.vuejs.org/en/advanced/navigation-guards.html#in-component-guards)). This commit adds corresponding change to README file with added hook so that new users are able to use it.