### PR TITLE
fix: fix nullable type in ts 2.6

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -34,7 +34,7 @@ export function componentFactory (
       options[key] = proto[key]
       return
     }
-    const descriptor = Object.getOwnPropertyDescriptor(proto, key)
+    const descriptor = Object.getOwnPropertyDescriptor(proto, key)!
     if (typeof descriptor.value === 'function') {
       // methods
       (options.methods || (options.methods = {}))[key] = descriptor.value


### PR DESCRIPTION
Fix #181 

TS 2.6 seems to change `Object.getOwnPropertyDescriptor`

Note `key` is already the property name, there is no need to check null in runtime.