### PR TITLE
fix: allow to reconfigure proxied properties in data hook

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -19,7 +19,8 @@ export function collectDataFromConstructor (vm: Vue, Component: VueClass<Vue>) {
       if (key.charAt(0) !== '_') {
         Object.defineProperty(this, key, {
           get: () => vm[key],
-          set: value => vm[key] = value
+          set: value => vm[key] = value,
+          configurable: true
         })
       }
     })

--- a/test/test-babel.js
+++ b/test/test-babel.js
@@ -90,4 +90,21 @@ describe('vue-class-component with Babel', () => {
     const vm = new MyComp()
     expect(vm.test).to.equal('foo')
   })
+
+  it('should not throw if property decorator declare some methods', () => {
+    const Test = createDecorator((options, key) => {
+      if (!options.methods) {
+        options.methods = {}
+      }
+      options.methods[key] = () => 'test'
+    })
+
+    @Component
+    class MyComp extends Vue {
+      @Test test
+    }
+
+    const vm = new MyComp()
+    expect(vm.test()).to.equal('test')
+  })
 })


### PR DESCRIPTION
Currently, Babel decorators cannot define `props` and `methods` because it tries to reconfigure proxied properties, then `Cannot redefine property` error is thrown.

This fix allows the users to create property decorators that declare props/methods in Babel.

This does not solve the difference between babel and ts decorator behaviors but I think it does not matter that users make their own custom decorator with caution.