### PR TITLE
fix: forward static functions in babel

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -65,12 +65,14 @@ export function componentFactory (
   const Super = superProto instanceof Vue
     ? superProto.constructor as VueClass<Vue>
     : Vue
-  const Extended = Super.extend(options);
+  const Extended = Super.extend(options)
 
-  for(let staticKey in Component) {
-    if(Component.hasOwnProperty(staticKey)) {
-      Extended[staticKey] = Component[staticKey];
+  Object.getOwnPropertyNames(Component).forEach(key => {
+    if (key !== 'prototype') {
+      const descriptor = Object.getOwnPropertyDescriptor(Component, key)!
+      Object.defineProperty(Extended, key, descriptor)
     }
-  }
-  return Extended;
+  })
+
+  return Extended
 }

--- a/test/test-babel.js
+++ b/test/test-babel.js
@@ -107,4 +107,18 @@ describe('vue-class-component with Babel', () => {
     const vm = new MyComp()
     expect(vm.test()).to.equal('test')
   })
+
+  it('should forward static members', () => {
+    @Component
+    class MyComp extends Vue {
+      static foo = 'foo'
+
+      static bar () {
+        return 'bar'
+      }
+    }
+
+    expect(MyComp.foo).to.equal('foo')
+    expect(MyComp.bar()).to.equal('bar')
+  })
 })

--- a/test/test.ts
+++ b/test/test.ts
@@ -274,13 +274,18 @@ describe('vue-class-component', () => {
     const vm: any = new MyComp()
     expect(vm.test).to.equal('foo')
   })
-  	
+
   it('forwardStatics', function () {
     @Component
     class MyComp extends Vue {
       static myValue = 52
+
+      static myFunc() {
+        return 42
+      }
     }
-    
-    expect(MyComp.myValue).to.equal(52);
+
+    expect(MyComp.myValue).to.equal(52)
+    expect(MyComp.myFunc()).to.equal(42)
   })
 })


### PR DESCRIPTION
Static methods are defined as non-enumerable properties in Babel, so Babel users cannot use static methods.

I've changed the implementation with `getOwnPropertyNames` and use the original property descriptor on defining the property on the extended constructor.

This also changes the extended constructor's `name` and `length` property. But it probably does not affect user's code.

fix #186 