### PR TITLE
Add VueDecorator to named exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import Vue, { ComponentOptions } from 'vue'
 import { VueClass } from './declarations'
 import { componentFactory, $internalHooks } from './component'
 
-export { createDecorator } from './util'
+export { createDecorator, VueDecorator } from './util'
 
 function Component <V extends Vue>(options: ComponentOptions<V> & ThisType<V>): <VC extends VueClass<V>>(target: VC) => VC
 function Component <VC extends VueClass<Vue>>(target: VC): VC


### PR DESCRIPTION
If you want to create a non-parameterized decorator you need to something like:

````ts
const newDecorator = const createDecorator((componentOptions, k) => { ...});
````

But that will give you the following error:

> Exported variable 'newDecorator' has or is using name 'VueDecorator' from external module