### PR TITLE
fix: fix memory leak of detached DOM tree

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -4,6 +4,7 @@ import { noop, warn } from './util'
 
 export function collectDataFromConstructor (vm: Vue, Component: VueClass<Vue>) {
   // override _init to prevent to init as Vue instance
+  const originalInit = Component.prototype._init
   Component.prototype._init = function (this: Vue) {
     // proxy to actual vm
     const keys = Object.getOwnPropertyNames(vm)
@@ -28,6 +29,9 @@ export function collectDataFromConstructor (vm: Vue, Component: VueClass<Vue>) {
 
   // should be acquired class property values
   const data = new Component()
+
+  // restore original _init to avoid memory leak (#209)
+  Component.prototype._init = originalInit
 
   // create plain data object
   const plainData = {}


### PR DESCRIPTION
The overwriting `_init` function causes memory leak because it retains the `vm` instance even after the `data` hook is finished. The `_init` function itself is also kept with the original component class. So we need to free the overwriting `_init` function after it is used.

fix #209 