### PR TITLE
chore: tidy up tsconfig.json

### DIFF
--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -5,12 +5,12 @@
       "dom",
       "es2015"
     ],
-    "module": "commonjs",
+    "module": "es2015",
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "strict": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "removeComments": true
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "include": [
     "./**/*.ts"

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import { VueClass } from './declarations'
-import { noop, warn } from './util'
+import { warn } from './util'
 
 export function collectDataFromConstructor (vm: Vue, Component: VueClass<Vue>) {
   // override _init to prevent to init as Vue instance

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,20 +1,8 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "es2015"
-    ],
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "isolatedModules": false,
-    "experimentalDecorators": true,
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "strictNullChecks": true,
-    "removeComments": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true
+    "outDir": "",
+    "experimentalDecorators": true
   },
   "include": [
     "./**/*.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,11 +8,11 @@
     "module": "es2015",
     "moduleResolution": "node",
     "outDir": "lib",
-    "experimentalDecorators": true,
     "declaration": true,
     "strict": true,
-    "suppressImplicitAnyIndexErrors": true,
-    "removeComments": true
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "suppressImplicitAnyIndexErrors": true
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
This PR updates tsconfigs in this repo.

* removed `experimentalDecorators` in base config since the lib itself does not use decorators.
* removed `removeComments` since they are eliminated in minification in any cases.
* use `extends` in tsconfig for test codes.
* added `noUnusedLocals` and `noUnusedParameters`.
* switched to `es2015` for `module` option in tsconfig for example code.