### PR TITLE
change compiler option "jsx";

### DIFF
--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -11,7 +11,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "jsx": "react",
+    "jsx": "preserve",
     "jsxFactory": "h"
   },
   "include": [


### PR DESCRIPTION
Hello, this pr resolves a bug caused by compiler option "jsx" which compiles file incorrectly. "react" option compiles to `.js` file using `React.createElement()` which does not work in some cases (e.g. cannot pass Prop from parent VNode correctly in jsx tag.). A better way is using "preserve" option compile `.tsx` to `.jsx` and then use babel to transform.