### PR TITLE
docs: separate props definition to make their types be inferable

### DIFF
--- a/example/App.vue
+++ b/example/App.vue
@@ -17,19 +17,21 @@ import Component from '../lib/index'
 import Hello from './Hello.vue'
 import World from './World'
 
-@Component({
+// We declare the props separately
+// to make props types inferable.
+const AppProps = Vue.extend({
   props: {
     propMessage: String
-  },
+  }
+})
+
+@Component({
   components: {
     Hello,
     World
   }
 })
-export default class App extends Vue {
-  // props have to be declared for typescript
-  propMessage!: string
-
+export default class App extends AppProps {
   // inital data
   msg: number = 123
 


### PR DESCRIPTION
I've updated the TypeScript example based on [this comment](https://github.com/vuejs/vue-class-component/issues/220#issuecomment-381557825) (thanks @KaelWD!) which eliminates redundant type definition for `props`. I guess this is a better way for TypeScript users since the `props` types are inferred by its `props` option unlike decorator approach.

/cc @HerringtonDarkholme @kaorun343 