### PR TITLE
Updated README. Call next() inside vue route hook to confirm navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,12 +171,12 @@ class MyComp extends Vue {
   // and beforeRouteLeave as Vue Router hooks
   beforeRouteEnter (to, from, next) {
     console.log('beforeRouteEnter')
-    next(); // needs to be called to confirm the navigation
+    next() // needs to be called to confirm the navigation
   }
 
   beforeRouteLeave (to, from, next) {
-    console.log('beforeRouteLeave');
-    next(); // needs to be called to confirm the navigation
+    console.log('beforeRouteLeave')
+    next() // needs to be called to confirm the navigation
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -169,12 +169,14 @@ import Component from 'vue-class-component'
 class MyComp extends Vue {
   // The class component now treats beforeRouteEnter
   // and beforeRouteLeave as Vue Router hooks
-  beforeRouteEnter () {
+  beforeRouteEnter (to: Route, from: Route, next: Function) {
     console.log('beforeRouteEnter')
+	next(); // needs to be called to confirm the navigation
   }
 
-  beforeRouteLeave () {
-    console.log('beforeRouteLeave')
+  beforeRouteLeave (to: Route, from: Route, next: Function) {
+    console.log('beforeRouteLeave');
+	next(); // needs to be called to confirm the navigation
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -169,14 +169,14 @@ import Component from 'vue-class-component'
 class MyComp extends Vue {
   // The class component now treats beforeRouteEnter
   // and beforeRouteLeave as Vue Router hooks
-  beforeRouteEnter (to: Route, from: Route, next: Function) {
+  beforeRouteEnter (to, from, next) {
     console.log('beforeRouteEnter')
-	next(); // needs to be called to confirm the navigation
+    next(); // needs to be called to confirm the navigation
   }
 
-  beforeRouteLeave (to: Route, from: Route, next: Function) {
+  beforeRouteLeave (to, from, next) {
     console.log('beforeRouteLeave');
-	next(); // needs to be called to confirm the navigation
+    next(); // needs to be called to confirm the navigation
   }
 }
 ```


### PR DESCRIPTION
Call next() inside vue-route hooks (i.e beforeRouteEnter and beforeRouteLeave) to confirm navigation otherwise route is not rendered.