### PR TITLE
Fix README mixin usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ import Component from 'vue-class-component'
 
 // You can declare a mixin as the same style as components.
 @Component
-export class MyMixin extends Vue {
+export default class MyMixin extends Vue {
   mixinValue = 'Hello'
 }
 ```


### PR DESCRIPTION
The mixin is exported as a named export but used as a default export.