### PR TITLE
fix: adds check forReflect.getOwnMetadataKeys

### DIFF
--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -1,7 +1,10 @@
 import Vue, { VueConstructor } from 'vue'
 import { VueClass } from './declarations'
 
-export const reflectionIsSupported = typeof Reflect !== 'undefined' && Reflect.defineMetadata
+// The rational behind the verbose Reflect-feature check below is the fact that there are polyfills
+// which add an implementation for Reflect.defineMetadata but not for Reflect.getOwnMetadataKeys.
+// Without this check consumers will encounter hard to track down runtime errors.
+export const reflectionIsSupported = typeof Reflect !== 'undefined' && Reflect.defineMetadata && Reflect.getOwnMetadataKeys
 
 export function copyReflectionMetadata (
   to: VueConstructor,


### PR DESCRIPTION
To be honest: I am not 100% certain that this change is good because it may simply hide an incorrect configuration on the part of the developer. However since there is already a check in place for the existence of `Reflect` adding a check for `Reflect.getOwnMetadataKeys` may also be warranted.