### PR TITLE
Passing `vm` to data constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,22 @@ class MyComp extends Vue {
 }
 ```
 
+#### `this` is not that
+
+When initializing properties using `this`, `this` refers to the original constructor's object. In order to access the `VM`, a constructor has to be written as it takes the `VM` as only argument.
+
+Instead of :
+```ts
+	selfValue = this
+```
+Use :
+```ts
+	selfValue: Vue
+	constructor(vm: Vue) {
+		this.selfValue = vm;
+	}
+```
+
 ### Build the Example
 
 ``` bash

--- a/src/data.ts
+++ b/src/data.ts
@@ -28,7 +28,7 @@ export function collectDataFromConstructor (vm: Vue, Component: VueClass<Vue>) {
   }
 
   // should be acquired class property values
-  const data = new Component()
+  const data = new Component(vm)
 
   // restore original _init to avoid memory leak (#209)
   Component.prototype._init = originalInit


### PR DESCRIPTION
In order to let the user initialize its data knowing the `vm`