### PR TITLE
[feat] Add serverPrefetch method from Vue 2.6

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -17,7 +17,8 @@ export const $internalHooks = [
   'activated',
   'deactivated',
   'render',
-  'errorCaptured' // 2.5
+  'errorCaptured', // 2.5
+  'serverPrefetch' // 2.6
 ]
 
 export function componentFactory (


### PR DESCRIPTION
Adding `serverPrefetch` to the list of internal methods for the vue class component. This is a new hook that lets you fetch data on the server for server side rendering.

https://ssr.vuejs.org/api/#serverprefetch