### PR TITLE
Build output ES6 module version

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -32,6 +32,10 @@ build([
   {
     file: resolve('dist/vue-class-component.common.js'),
     format: 'cjs'
+  },
+  {
+    file: resolve('dist/vue-class-component.esm.js'),
+    format: 'esm'
   }
 ].map(genConfig))
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "7.0.2",
   "description": "ES201X/TypeScript class decorator for Vue components",
   "main": "dist/vue-class-component.common.js",
+  "module": "dist/vue-class-component.esm.js",
   "typings": "lib/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
This proposed change adds a ES6 module output to the build, for use with ES6 module-aware bundlers such as rollup.