### PR TITLE
check reflectionIsSupported in decorator runtime

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -83,7 +83,7 @@ export function componentFactory (
 
   forwardStaticMembers(Extended, Component, Super)
 
-  if (reflectionIsSupported) {
+  if (reflectionIsSupported()) {
     copyReflectionMetadata(Extended, Component)
   }
 

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -5,7 +5,7 @@ import { VueClass } from './declarations'
 // which add an implementation for Reflect.defineMetadata but not for Reflect.getOwnMetadataKeys.
 // Without this check consumers will encounter hard to track down runtime errors.
 export function reflectionIsSupported () {
-  return typeof Reflect !== 'undefined' && Reflect.defineMetadata && Reflect.getOwnMetadataKeys;
+  return typeof Reflect !== 'undefined' && Reflect.defineMetadata && Reflect.getOwnMetadataKeys
 }
 
 export function copyReflectionMetadata (

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -4,7 +4,9 @@ import { VueClass } from './declarations'
 // The rational behind the verbose Reflect-feature check below is the fact that there are polyfills
 // which add an implementation for Reflect.defineMetadata but not for Reflect.getOwnMetadataKeys.
 // Without this check consumers will encounter hard to track down runtime errors.
-export const reflectionIsSupported = typeof Reflect !== 'undefined' && Reflect.defineMetadata && Reflect.getOwnMetadataKeys
+export function reflectionIsSupported () {
+  return typeof Reflect !== 'undefined' && Reflect.defineMetadata && Reflect.getOwnMetadataKeys;
+}
 
 export function copyReflectionMetadata (
   to: VueConstructor,


### PR DESCRIPTION
In [this commit](https://github.com/vuejs/vue-class-component/pull/284/commits/8022c7a59a35034a3f6b31310360e195fd9d4103), `reflectionIsSupported` has been refactored from `(Reflect && Reflect.defineMetadata) !== undefined` to `typeof Reflect !== undefined && Reflect.defineMetadata`.

But also, from decorator runtime (function) check to one-time check on `import` (var). Which caused a small issue:

I've faced a situation, where one of my dependencies brings `reflect-metadata` as it's own dependency, and being imported after `vue-class-component` package.
When decorating is applied, metadata already treated as unsupported and metadata is lost.

The only way to solve this is to import `reflect-metadata` before our main `App` module (in other words, before decorated are applied).

But in my case, I don't need `reflect-metadata`, except for this dependency. Even more, this dependency is used only during development and not imported in production.

This PR can solve this issue.