### PR TITLE
docs(props-definition): added 'PropType' usage example

### DIFF
--- a/docs/guide/props-definition.md
+++ b/docs/guide/props-definition.md
@@ -29,6 +29,47 @@ export default class Greeting extends GreetingProps {
 </script>
 ```
 
+Another example, involving interface as a property type:
+
+```ts
+export default interface IPerson {
+  firstName: string;
+  lastName: string;
+}
+```
+
+
+```vue
+<template>
+  <div>{{ message }}</div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue'
+import Component from 'vue-class-component'
+import IPerson from './IPerson'
+
+// Define the props by using Vue's canonical way.
+const GreetingProps = Vue.extend({
+  props: {
+    person: {
+      type: Object as PropType<IPerson>
+    }
+  }
+})
+
+// Use defined props by extending GreetingProps.
+@Component
+export default class Greeting extends GreetingProps {
+  get message(): string {
+    // this.name will be typed
+    return 'Hello, ' + this.person.firstName + ' ' + this.person.lastName
+  }
+}
+</script>
+```
+
+
 As `Vue.extend` infers defined prop types, it is possible to use them in your class component by extending it.
 
 If you have a super class component or mixins to extend, use `mixins` helper to combine defined props with them:


### PR DESCRIPTION
As explained in https://github.com/vuejs/vue-class-component/issues/409, this PR adds example of `PropType` usage to documentation