### PR TITLE
feat: mark as side effect free to enable efficient tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "dist/vue-class-component.esm.js",
   "unpkg": "dist/vue-class-component.js",
   "typings": "lib/index.d.ts",
+  "sideEffects": false,
   "files": [
     "dist",
     "lib",


### PR DESCRIPTION
Adding `sideEffects: false` helps webpack to tree-shake the user code includes vue-class-component.
https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free