### PR TITLE
add note for missing v8 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ ECMAScript / TypeScript decorator for class-style Vue components.
 
 See [https://class-component.vuejs.org](https://class-component.vuejs.org)
 
+> Please note, documentation for v8 is not ready yet. Check out the readme in the respective branch or see [v8 proposals in the issue list](https://github.com/vuejs/vue-class-component/issues?q=is%3Aopen+is%3Aissue+label%3Av8)
+
 ## Online one-click setup for contributing
 
 Contribute to Vue Class Component using a fully featured online development environment that will automatically: clone the repo, install the dependencies and start the docs web server and run `yarn dev`.


### PR DESCRIPTION
Had a hard time to find info on @Options decorator. Please consider adding this to spare other users some time.