### PR TITLE
Add support for static properties

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -74,6 +74,12 @@ export function componentFactory (
     delete (Component as DecoratedClass).__decorators__
   }
 
+  // static properties
+  const components = Component.components
+  if (components) {
+    options.components = components
+  }
+
   // find super
   const superProto = Object.getPrototypeOf(Component.prototype)
   const Super = superProto instanceof Vue

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -1,6 +1,8 @@
 import Vue, { ComponentOptions } from 'vue'
 
-export type VueClass<V> = { new (...args: any[]): V & Vue } & typeof Vue
+export type VueClass<V> = { new (...args: any[]): V & Vue } & typeof Vue & {
+    components?: Record<string, VueClass<Vue>>;
+  };
 
 export type DecoratedClass = VueClass<Vue> & {
   // Property, method and parameter decorators created by `createDecorator` helper

--- a/test/test-babel.js
+++ b/test/test-babel.js
@@ -29,6 +29,21 @@ describe('vue-class-component with Babel', () => {
     expect(c.bar).to.equal(2)
   })
 
+  it('should collect static components', () => {
+
+    @Component
+    class OtherComponent extends Vue {}
+
+    @Component
+    class MyComp extends Vue {
+      static components = [
+        OtherComponent
+      ]
+    }
+
+    expect(MyComp.components[0]).to.equal(OtherComponent)
+  })
+
   it('should collect decorated class properties', () => {
     const valueDecorator = (value) => () => {
       return {


### PR DESCRIPTION
Typescript decorators have a known issue that they can't mutate their target types. See extended discussion here: https://github.com/microsoft/TypeScript/issues/4881

What this means is that if we use the `@Component` decorator syntax, we have no way to add any statically extractable components list if we pass any. This prevents advanced usages of Typescript components.

However if we allow the consumers to define a `static components` property, tools like Volar - https://github.com/johnsoncodehk/volar (which also includes vue-tsc) can extract the child-component types.

Another benefit to this is that we don't need to introduce a breaking change, as if someone defined a static property in their class components right now `vue-class-component` will not extract them anyway.