### PR TITLE
Deprecate this and recommend Vue Facing Decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-# Vue Class Component
+# [DEPRECATED] Vue Class Component
+
+
+## ⚠️ Notice
+
+This library is no longer actively maintained. It is no longer recommend to use Class-based components in Vue 3. The recommended way to use Vue 3 in large applications is Single-File Components, Composition API, and `<script setup>`. If you still want to use classes, check out the community-maintained project [`vue-facing-decorator`](https://facing-dev.github.io/vue-facing-decorator/#/).
+
+---
 
 ECMAScript / TypeScript decorator for class-style Vue components.
 
-[![npm](https://img.shields.io/npm/v/vue-class-component.svg)](https://www.npmjs.com/package/vue-class-component) [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/vuejs/vue-class-component) 
-
-## Notice
-
-This library is no longer actively maintained. For an alternative that is receiving ongoing development, check [`vue-facing-decorator`](https://facing-dev.github.io/vue-facing-decorator/#/).
+[![npm](https://img.shields.io/npm/v/vue-class-component.svg)](https://www.npmjs.com/package/vue-class-component) [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/vuejs/vue-class-component)
 
 ## Document
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ ECMAScript / TypeScript decorator for class-style Vue components.
 
 [![npm](https://img.shields.io/npm/v/vue-class-component.svg)](https://www.npmjs.com/package/vue-class-component) [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/vuejs/vue-class-component) 
 
+## Notice
+
+This library is no longer actively maintained. For an alternative that is receiving ongoing development, check [`vue-facing-decorator`](https://facing-dev.github.io/vue-facing-decorator/#/).
+
 ## Document
 
 See [https://class-component.vuejs.org](https://class-component.vuejs.org)


### PR DESCRIPTION
No-one in the Vue.js org is maintaining this. I think we should deprecate, or at least let people know it's not getting active updates, and point them to a more up to date alternative.