### PR TITLE
Docs: Add vue-class-migrator reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 This library is no longer actively maintained. It is no longer recommend to use Class-based components in Vue 3. The recommended way to use Vue 3 in large applications is Single-File Components, Composition API, and `<script setup>`. If you still want to use classes, check out the community-maintained project [`vue-facing-decorator`](https://facing-dev.github.io/vue-facing-decorator/#/).
 
+Additionally, if you're interested in migrating out of class components, you might find the CLI tool [`vue-class-migrator`](https://github.com/getyourguide/vue-class-migrator) helpful for the transition.
+
 ---
 
 ECMAScript / TypeScript decorator for class-style Vue components.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,9 @@
 
 :::warning
 This library is no longer actively maintained. It is no longer recommend to use Class-based components in Vue 3. The recommended way to use Vue 3 in large applications is Single-File Components, Composition API, and `<script setup>`. If you still want to use classes, check out the community-maintained project [`vue-facing-decorator`](https://facing-dev.github.io/vue-facing-decorator/#/).
+
+Additionally, if you're interested in migrating out of class components, you might find the CLI tool [`vue-class-migrator`](https://github.com/getyourguide/vue-class-migrator) helpful for the transition.
+
 :::
 
 Vue Class Component is a library that lets you make your Vue components in class-style syntax. For example, below is a simple counter component written with Vue Class Component:


### PR DESCRIPTION
**Context**

In light of shifting recommendations away from Vue Class Components, the [vue-class-migrator](https://github.com/getyourguide/vue-class-migrator) CLI is as a valuable tool for easing this transition.

This command-line utility simplifies the migration process, resulting in significant time savings. My aim is to contribute this tool to the community, making it accessible for others to benefit from.

I propose that integrating it into the [deprecation notice](https://github.com/vuejs/vue-class-component) would be a highly beneficial step, as it could provide substantial assistance to developers undergoing a similar transition.

For additional insights, you can refer to the related article [here](https://www.getyourguide.careers/posts/vue-3-migrating-through-automation).

@lmiller1990 